### PR TITLE
Add WithUpstreamOptions server option

### DIFF
--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/temporal"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -106,6 +107,9 @@ func buildCLI() *cli.App {
 					temporalite.WithFrontendPort(c.Int(portFlag)),
 					temporalite.WithDatabaseFilePath(c.String(dbPathFlag)),
 					temporalite.WithNamespaces(c.StringSlice(namespaceFlag)...),
+					temporalite.WithUpstreamOptions(
+						temporal.InterruptOn(temporal.InterruptCh()),
+					),
 				}
 				if c.Bool(ephemeralFlag) {
 					opts = append(opts, temporalite.WithPersistenceDisabled())

--- a/internal/liteconfig/config.go
+++ b/internal/liteconfig/config.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
+	"go.temporal.io/server/temporal"
 )
 
 const (
@@ -30,6 +31,7 @@ type Config struct {
 	DynamicPorts     bool
 	Namespaces       []string
 	Logger           log.Logger
+	UpstreamOptions  []temporal.ServerOption
 	portProvider     *portProvider
 }
 

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ package temporalite
 
 import (
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/temporal"
 
 	"github.com/DataDog/temporalite/internal/liteconfig"
 )
@@ -51,6 +52,13 @@ func WithDynamicPorts() ServerOption {
 func WithNamespaces(namespaces ...string) ServerOption {
 	return newApplyFuncContainer(func(cfg *liteconfig.Config) {
 		cfg.Namespaces = append(cfg.Namespaces, namespaces...)
+	})
+}
+
+// WithUpstreamOptions registers Temporal server options.
+func WithUpstreamOptions(options ...temporal.ServerOption) ServerOption {
+	return newApplyFuncContainer(func(cfg *liteconfig.Config) {
+		cfg.UpstreamOptions = options
 	})
 }
 

--- a/options.go
+++ b/options.go
@@ -58,7 +58,7 @@ func WithNamespaces(namespaces ...string) ServerOption {
 // WithUpstreamOptions registers Temporal server options.
 func WithUpstreamOptions(options ...temporal.ServerOption) ServerOption {
 	return newApplyFuncContainer(func(cfg *liteconfig.Config) {
-		cfg.UpstreamOptions = options
+		cfg.UpstreamOptions = append(cfg.UpstreamOptions, options...)
 	})
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I'm adding a new server option `WithUpstreamOptions(options ...temporal.ServerOption)` enabling users to configure the Temporal server more granularly., e.g.:

```golang
opts := []temporalite.ServerOption{
    temporalite.WithNamespaces("default"),
    temporalite.WithDynamicPorts(),
    temporalite.WithPersistenceDisabled(),
    temporalite.WithUpstreamOptions(
        temporal.ForServices([]string{primitives.FrontendService}),
    ),
}
srv, err := temporalite.NewServer(opts...)
```

<!-- Tell your future self why have you made these changes -->
**Why?**
This allows users configuring all server options, like [InterruptOn](`https://docs.temporal.io/docs/server/options/#interrupton`), without the maintenance burden of having dedicated functions.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is a backward incompatible change. Before, `temporal.InterruptOn(temporal.InterruptCh())` was used. This pull request proposes to leave the interrupt option undefined to match [Temporal's default](https://docs.temporal.io/docs/server/options/#interrupton).

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
