### PR TITLE
Expose frontend host:port

### DIFF
--- a/server.go
+++ b/server.go
@@ -127,6 +127,9 @@ func (s *Server) NewClientWithOptions(ctx context.Context, options client.Option
 }
 
 // FrontendHostPort returns the host:port for this server.
+//
+// When constructing a Temporalite client from within the same process,
+// NewClient or NewClientWithOptions should be used instead.
 func (s *Server) FrontendHostPort() string {
 	return s.frontendHostPort
 }

--- a/server.go
+++ b/server.go
@@ -126,6 +126,11 @@ func (s *Server) NewClientWithOptions(ctx context.Context, options client.Option
 	return client.NewClient(options)
 }
 
+// FrontendHostPort returns the host:port for this server.
+func (s *Server) FrontendHostPort() string {
+	return s.frontendHostPort
+}
+
 func timeoutFromContext(ctx context.Context, defaultTimeout time.Duration) time.Duration {
 	if deadline, ok := ctx.Deadline(); ok {
 		return deadline.Sub(time.Now())


### PR DESCRIPTION
**What changed?**

Exposed `FrontendHostPort`

**Why?**

Some uses of temporalite may want to use this value for their own client creation, or in my case, pass it somewhere else for their use.

Ideally this would be `FrontendAddr() net.Addr` and the system would support things like local unix paths and such, but I understand this is a Temporal server limitation too. I also considered just exposing `FrontendPort` since `127.0.0.1` is hardcoded, but I assumed it may not be hardcoded always and `host:port` can be directly passed to different forms of `Dial`.

**How did you test it?**

Untested getter.

**Potential risks**

None

**Is hotfix candidate?**

No