### PR TITLE
Add Dockerfile to support running in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.17 as builder
+
+WORKDIR ${GOPATH:-/go}/src/temporalite
+
+COPY . .
+RUN go mod download
+RUN go get -d -v ./...
+
+RUN go build -o ${GOPATH:-/go}/bin/ ${GOPATH:-/go}/src/temporalite/cmd/temporalite
+
+FROM gcr.io/distroless/base-debian11
+
+COPY --from=builder ${GOPATH:-/go}/bin/temporalite /
+EXPOSE 7233
+
+ENTRYPOINT ["/temporalite", "start", "--ephemeral", "-n", "default", "--ip" , "0.0.0.0"]


### PR DESCRIPTION
Adding Dockerfile for demo purposes with temporal ui

<!-- Describe what has changed in this PR -->
**What changed?**
Adding a Dockerfile for local development

<!-- Tell your future self why have you made these changes -->
**Why?**
Setting up a local development environment using
https://github.com/jbreiding/potential-goggles

To work on and demo both code bases.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
docker and docker-compose
vscode devcontainers
GH codespaces


``` sh
$ docker build -t temporalite:testv2 . --no-cache
$ docker run temporalite:testv2
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.