### PR TITLE
Use dynamic ports from CLI

### DIFF
--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -157,6 +157,7 @@ func buildCLI() *cli.App {
 				}
 
 				opts := []temporalite.ServerOption{
+					temporalite.WithDynamicPorts(),
 					temporalite.WithFrontendPort(serverPort),
 					temporalite.WithFrontendIP(ip),
 					temporalite.WithDatabaseFilePath(c.String(dbPathFlag)),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Updates the `temporalite` CLI to always use dynamic ports.

<!-- Tell your future self why have you made these changes -->
**Why?**

Previously ports for internal APIs were assigned by adding a hardcoded offset to the frontend grpc port. About 10 ports are computed in this way, leading to a high chance of conflicts.

Closes #34.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Some users may have been depending on the previous behavior, since pprof and metrics ports were predictable (though this was never documented). Explicit flags for setting those ports can be added later.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No