### PR TITLE
fix: log level support

### DIFF
--- a/internal/liteconfig/config.go
+++ b/internal/liteconfig/config.go
@@ -88,7 +88,7 @@ func NewDefaultConfig() (*Config, error) {
 		SQLitePragmas:    nil,
 		Logger: log.NewZapLogger(log.BuildZapLogger(log.Config{
 			Stdout:     true,
-			Level:      "debug",
+			Level:      "info",
 			OutputFile: "",
 		})),
 		portProvider: &portProvider{},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding an optional flag to set log level.


<!-- Tell your future self why have you made these changes -->
**Why?**
Closes #57 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
go run ./cmd/temporalite/ start --ephemeral --log-level=info
go run ./cmd/temporalite/ start --ephemeral --log-level=debug
go run ./cmd/temporalite/ start --ephemeral --log-level=info --log-format=pretty
go run ./cmd/temporalite/ start --ephemeral --log-level=debug --log-format=pretty
go run ./cmd/temporalite/ start --ephemeral 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
log level default (if omitted) is changed to info from debug

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no