### PR TITLE
Include a note on Getting Started for Windows into the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Build from source using [go install](https://golang.org/ref/mod#go-install):
 
 > Note: Go 1.18 or greater is currently required.
 
+> Note: On Windows, first, make sure that you have Go and GCC installed:
+> * Go: https://go.dev/doc/install
+> * GCC: https://jmeubank.github.io/tdm-gcc/ (pick an install for both 32 & 64 bit)
+
 ```bash
 go install github.com/DataDog/temporalite/cmd/temporalite@latest
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Build from source using [go install](https://golang.org/ref/mod#go-install):
 
 > Note: On Windows, first, make sure that you have Go and GCC installed:
 > * Go: https://go.dev/doc/install
-> * GCC: https://jmeubank.github.io/tdm-gcc/ (pick an install for both 32 & 64 bit)
+> * GCC: https://jmeubank.github.io/tdm-gcc/ (pick an install for both, 32 & 64 bits)
 
 ```bash
 go install github.com/DataDog/temporalite/cmd/temporalite@latest


### PR DESCRIPTION
**What changed?**

A small note is added to the ReadMe to call out dependencies that need to be installed on a Windows machine in order to install Temporal Lite.

**Why?**

Thanks for creating the Temporal Lite distribution! It makes getting Temporal started a lot faster.
Unfortunately, the current Getting Started section in the ReadMe assumes a regular GO developer.
By now, Temporal is used across many languages, and not all folks have the full context.
I suggest to add a small note to the ReadMe file, that will save many folks who do not have the right setup already a bunch of time during the initial setup.

(I know, because I jest went though it myself. 😄 )