### PR TITLE
Add --metrics-port flag.

### DIFF
--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -35,17 +35,18 @@ var (
 )
 
 const (
-	ephemeralFlag = "ephemeral"
-	dbPathFlag    = "filename"
-	portFlag      = "port"
-	uiPortFlag    = "ui-port"
-	headlessFlag  = "headless"
-	ipFlag        = "ip"
-	logFormatFlag = "log-format"
-	logLevelFlag  = "log-level"
-	namespaceFlag = "namespace"
-	pragmaFlag    = "sqlite-pragma"
-	configFlag    = "config"
+	ephemeralFlag   = "ephemeral"
+	dbPathFlag      = "filename"
+	portFlag        = "port"
+	metricsPortFlag = "metrics-port"
+	uiPortFlag      = "ui-port"
+	headlessFlag    = "headless"
+	ipFlag          = "ip"
+	logFormatFlag   = "log-format"
+	logLevelFlag    = "log-level"
+	namespaceFlag   = "namespace"
+	pragmaFlag      = "sqlite-pragma"
+	configFlag      = "config"
 )
 
 func init() {
@@ -92,6 +93,11 @@ func buildCLI() *cli.App {
 					Aliases: []string{"p"},
 					Usage:   "port for the temporal-frontend GRPC service",
 					Value:   liteconfig.DefaultFrontendPort,
+				},
+				&cli.IntFlag{
+					Name:  metricsPortFlag,
+					Usage: "port for the metrics listener",
+					Value: liteconfig.DefaultMetricsPort,
 				},
 				&cli.IntFlag{
 					Name:        uiPortFlag,
@@ -171,9 +177,10 @@ func buildCLI() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 				var (
-					ip         = c.String(ipFlag)
-					serverPort = c.Int(portFlag)
-					uiPort     = serverPort + 1000
+					ip          = c.String(ipFlag)
+					serverPort  = c.Int(portFlag)
+					metricsPort = c.Int(metricsPortFlag)
+					uiPort      = serverPort + 1000
 				)
 
 				if c.IsSet(uiPortFlag) {
@@ -196,6 +203,7 @@ func buildCLI() *cli.App {
 				opts := []temporalite.ServerOption{
 					temporalite.WithDynamicPorts(),
 					temporalite.WithFrontendPort(serverPort),
+					temporalite.WithMetricsPort(metricsPort),
 					temporalite.WithFrontendIP(ip),
 					temporalite.WithDatabaseFilePath(c.String(dbPathFlag)),
 					temporalite.WithNamespaces(c.StringSlice(namespaceFlag)...),

--- a/internal/liteconfig/config.go
+++ b/internal/liteconfig/config.go
@@ -151,7 +151,7 @@ func Convert(cfg *Config) *config.Config {
 	}
 	baseConfig.Global.Metrics = &metrics.Config{
 		Prometheus: &metrics.PrometheusConfig{
-			ListenAddress: fmt.Sprintf("%s:%d", broadcastAddress, cfg.MetricsPort),
+			ListenAddress: fmt.Sprintf("%s:%d", cfg.FrontendIP, cfg.MetricsPort),
 			HandlerPath:   "/metrics",
 		},
 	}
@@ -214,28 +214,28 @@ func Convert(cfg *Config) *config.Config {
 	return baseConfig
 }
 
-func (o *Config) mustGetService(frontendPortOffset int) config.Service {
+func (cfg *Config) mustGetService(frontendPortOffset int) config.Service {
 	svc := config.Service{
 		RPC: config.RPC{
-			GRPCPort:        o.FrontendPort + frontendPortOffset,
-			MembershipPort:  o.FrontendPort + 100 + frontendPortOffset,
+			GRPCPort:        cfg.FrontendPort + frontendPortOffset,
+			MembershipPort:  cfg.FrontendPort + 100 + frontendPortOffset,
 			BindOnLocalHost: true,
 			BindOnIP:        "",
 		},
 	}
 
 	// Assign any open port when configured to use dynamic ports
-	if o.DynamicPorts {
+	if cfg.DynamicPorts {
 		if frontendPortOffset != 0 {
-			svc.RPC.GRPCPort = o.portProvider.mustGetFreePort()
+			svc.RPC.GRPCPort = cfg.portProvider.mustGetFreePort()
 		}
-		svc.RPC.MembershipPort = o.portProvider.mustGetFreePort()
+		svc.RPC.MembershipPort = cfg.portProvider.mustGetFreePort()
 	}
 
 	// Optionally bind frontend to IPv4 address
-	if frontendPortOffset == 0 && o.FrontendIP != "" {
+	if frontendPortOffset == 0 && cfg.FrontendIP != "" {
 		svc.RPC.BindOnLocalHost = false
-		svc.RPC.BindOnIP = o.FrontendIP
+		svc.RPC.BindOnIP = cfg.FrontendIP
 	}
 
 	return svc

--- a/options.go
+++ b/options.go
@@ -57,6 +57,15 @@ func WithFrontendPort(port int) ServerOption {
 	})
 }
 
+// WithMetricsPort sets the listening port for metrics.
+//
+// When unspecified, the port will be system-chosen.
+func WithMetricsPort(port int) ServerOption {
+	return newApplyFuncContainer(func(cfg *liteconfig.Config) {
+		cfg.MetricsPort = port
+	})
+}
+
 // WithFrontendIP binds the temporal-frontend GRPC service to a specific IP (eg. `0.0.0.0`)
 // Check net.ParseIP for supported syntax; only IPv4 is supported.
 //


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added command line flag to set the metrics port.

<!-- Tell your future self why have you made these changes -->
**Why?**

Without this temporalite is not easily useable in situations where users would like to scrape the metrics.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

**How did you test it?**

Ran with `--metrics-port ..` and check that I could scrape on the expected port.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

**Potential risks**

None. Default behaviour remains as it was.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->

**Is hotfix candidate?**

No.