### PR TITLE
Test with CGO disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
         - ""
         - -tags headless
         cgo: ["0", "1"]
-        exclude:
-        # cgo is currently required by the upstream SQLite driver.
-        # This exception should be removed if/when non-cgo builds are supported again.
-        - cgo: "0"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Now that CGO is no longer a requirement of the SQLite driver, we can enable tests with CGO disabled in CI.

<!-- Tell your future self why have you made these changes -->
**Why?**

Validate that Temporalite works in environments where CGO is not available.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No